### PR TITLE
Explicitly depend on react/event-loop

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,6 +11,7 @@
         }
     ],
     "require": {
+        "react/event-loop": "0.3.*",
         "clue/socket-react": "0.2.*"
     },
     "autoload": {

--- a/composer.lock
+++ b/composer.lock
@@ -1,9 +1,10 @@
 {
     "_readme": [
         "This file locks the dependencies of your project to a known state",
-        "Read more about it at http://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file"
+        "Read more about it at http://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
+        "This file is @generated automatically"
     ],
-    "hash": "b46b8ef46f911774265cb1806ec0e689",
+    "hash": "0cff51ab428979b6da8f99ddb5870a05",
     "packages": [
         {
             "name": "clue/datagram",


### PR DESCRIPTION
The code has an explicit dependency on React's event-loop component, hence we should explicitly define it as a dependency.

Currently, it's (implicitly) installed as part of a dependency of the clue/socket-react package. IMHO this is an implementation detail that we should not rely on.

Updated dependency graph:
![graph-composer](https://cloud.githubusercontent.com/assets/776829/3275146/370de380-f338-11e3-9861-2ecadfa37418.png)
